### PR TITLE
set mysqldb charset inside container

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $   mysql
 Now alter the `charset`:
 
 ```bash
-$ mysql -h 127.0.0.1 -u root --password=123456 -e 'ALTER DATABASE openoni charset=utf8;'
+$ docker exec mysql mysql -u root --password=123456 -e 'ALTER DATABASE openoni charset=utf8';
 ```
 
 Solr

--- a/dev.sh
+++ b/dev.sh
@@ -2,6 +2,7 @@
 
 IP_ADDRESS=${1:-127.0.0.1}
 DELAY=${2:-10} # interval to wait for dependent docker services to initialize
+MYSQL_ROOT_PASSWORD=123456
 
 docker stop open-oni-dev || true
 docker rm open-oni-dev || true
@@ -13,14 +14,15 @@ echo "Starting mysql ..."
 docker run -d \
   -p 3306:3306 \
   --name mysql \
-  -e MYSQL_ROOT_PASSWORD=123456 \
+  -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD \
   -e MYSQL_DATABASE=openoni \
   -e MYSQL_USER=openoni \
   -e MYSQL_PASSWORD=openoni \
   mysql || true
 
 sleep $DELAY
-mysql -h $IP_ADDRESS -u root --password=123456 -e 'ALTER DATABASE openoni charset=utf8;'
+
+docker exec mysql mysql -u root --password=$MYSQL_ROOT_PASSWORD -e 'ALTER DATABASE openoni charset=utf8';
 
 echo "Starting solr ..."
 export SOLR=4.10.4


### PR DESCRIPTION
The current dev.sh assumes that a mysql command line client is installed.
Instead we can run the alter command from within the container.

Ultimately I think we would want to have mysql container use the version
controlled mysql config in open-oni/conf/my.cnf

fixes https://github.com/open-oni/open-oni/issues/58
