### PR TITLE
Add shebang to pip-install.sh

### DIFF
--- a/pip-install.sh
+++ b/pip-install.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Installs pip dependencies
 cd /opt/openoni
 virtualenv ENV


### PR DESCRIPTION
Fixes docker crash when running via `docker exec`
