### PR TITLE
Issue/#13 check mysql startup completion in dev.sh

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 IP_ADDRESS=${1:-127.0.0.1}
-DELAY=${2:-10} # interval to wait for dependent docker services to initialize
+DELAY=${2:-60} # interval to wait for dependent docker services to initialize
 MYSQL_ROOT_PASSWORD=123456
 PORT=${DOCKERPORT:-80}
 
@@ -18,7 +18,7 @@ docker build -t open-oni:dev -f Dockerfile-dev .
 
 echo "Starting mysql ..."
 docker run -d \
-  -p 3307:3306 \
+  -p 3306:3306 \
   --name mysql \
   -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD \
   -e MYSQL_DATABASE=openoni \

--- a/dev.sh
+++ b/dev.sh
@@ -24,7 +24,9 @@ docker run -d \
   -e MYSQL_DATABASE=openoni \
   -e MYSQL_USER=openoni \
   -e MYSQL_PASSWORD=openoni \
-  mysql && sleep $DELAY
+  mysql
+
+docker exec mysql mysqladmin --silent --wait=30 ping || exit 1
 
 docker exec mysql mysql -u root --password=$MYSQL_ROOT_PASSWORD -e 'ALTER DATABASE openoni charset=utf8';
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 IP_ADDRESS=${1:-127.0.0.1}
-SOLRDELAY=${SOLRDELAY:-20} # interval to wait for dependent docker services to initialize
+SOLRDELAY=${SOLRDELAY:-10} # interval to wait for dependent docker services to initialize
 MYSQL_ROOT_PASSWORD=123456
 PORT=${DOCKERPORT:-80}
 DB_READY=0

--- a/dev.sh
+++ b/dev.sh
@@ -48,9 +48,6 @@ do
  fi
 done
 
-
-#docker exec mysql mysql -u root --password=$MYSQL_ROOT_PASSWORD -e 'ALTER DATABASE openoni charset=utf8';
-
 # set up access to a test database, for masochists
 echo "setting up a test database ..."
 docker exec mysql mysql -u root --password=$MYSQL_ROOT_PASSWORD -e 'USE mysql;

--- a/dev.sh
+++ b/dev.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
 IP_ADDRESS=${1:-127.0.0.1}
-DELAY=${2:-60} # interval to wait for dependent docker services to initialize
+SOLRDELAY=${SOLRDELAY:-20} # interval to wait for dependent docker services to initialize
 MYSQL_ROOT_PASSWORD=123456
 PORT=${DOCKERPORT:-80}
+DB_READY=0
+TRIES=0
+MAX_TRIES=12
 
 docker stop open-oni-dev || true
 docker rm open-oni-dev || true
@@ -26,11 +29,30 @@ docker run -d \
   -e MYSQL_PASSWORD=openoni \
   mysql
 
-docker exec mysql mysqladmin -uroot -p$MYSQL_ROOT_PASSWORD --silent --wait=$DELAY ping || exit 1
+while [ $DB_READY == 0 ]
+do
+ if
+   ! docker exec mysql mysql -uroot -p$MYSQL_ROOT_PASSWORD \
+     -e 'ALTER DATABASE openoni charset=utf8' > /dev/null 2>/dev/null
+ then
+   SLEEP 5
+   let TRIES++
+   echo "Looks like we're still waiting for MySQL ... 5 more seconds ... retry $TRIES of $MAX_TRIES" 
+   if [ "$TRIES" = "$MAX_TRIES" ]
+   then
+    echo "Looks like we couldn't get MySQL running. Could you check settings and try again?"
+    exit 2
+   fi
+ else
+   DB_READY=1
+ fi
+done
 
-docker exec mysql mysql -u root --password=$MYSQL_ROOT_PASSWORD -e 'ALTER DATABASE openoni charset=utf8';
+
+#docker exec mysql mysql -u root --password=$MYSQL_ROOT_PASSWORD -e 'ALTER DATABASE openoni charset=utf8';
 
 # set up access to a test database, for masochists
+echo "setting up a test database ..."
 docker exec mysql mysql -u root --password=$MYSQL_ROOT_PASSWORD -e 'USE mysql;
 GRANT ALL on test_openoni.* TO "openoni"@"%" IDENTIFIED BY "openoni";';
 
@@ -41,7 +63,7 @@ docker run -d \
   --name solr \
   -v /$(pwd)/solr/schema.xml:/opt/solr/example/solr/collection1/conf/schema.xml \
   -v /$(pwd)/solr/solrconfig.xml:/opt/solr/example/solr/collection1/conf/solrconfig.xml \
-  makuk66/docker-solr:$SOLR && sleep $DELAY
+  makuk66/docker-solr:$SOLR && sleep $SOLRDELAY
 
 echo "Starting open-oni for development ..."
 

--- a/dev.sh
+++ b/dev.sh
@@ -18,7 +18,7 @@ docker build -t open-oni:dev -f Dockerfile-dev .
 
 echo "Starting mysql ..."
 docker run -d \
-  -p 3306:3306 \
+  -p 3307:3306 \
   --name mysql \
   -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD \
   -e MYSQL_DATABASE=openoni \
@@ -26,7 +26,7 @@ docker run -d \
   -e MYSQL_PASSWORD=openoni \
   mysql
 
-docker exec mysql mysqladmin --silent --wait=30 ping || exit 1
+docker exec mysql mysqladmin -uroot -p$MYSQL_ROOT_PASSWORD --silent --wait=$DELAY ping || exit 1
 
 docker exec mysql mysql -u root --password=$MYSQL_ROOT_PASSWORD -e 'ALTER DATABASE openoni charset=utf8';
 

--- a/dev.sh
+++ b/dev.sh
@@ -35,7 +35,7 @@ do
    ! docker exec mysql mysql -uroot -p$MYSQL_ROOT_PASSWORD \
      -e 'ALTER DATABASE openoni charset=utf8' > /dev/null 2>/dev/null
  then
-   SLEEP 5
+   sleep 5
    let TRIES++
    echo "Looks like we're still waiting for MySQL ... 5 more seconds ... retry $TRIES of $MAX_TRIES" 
    if [ "$TRIES" = "$MAX_TRIES" ]


### PR DESCRIPTION
fixes #13 by using mysqladmin to check if mysql is alive. Through a carefully constructed syngergy between docker command line exec and delay variable. ;-)
