### PR TITLE
people need to belong to open-oni to be able to pull via ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Open ONI Development
 Clone this repo, and then clone open-oni inside it:
 
 ```bash
-git clone git@github.com:open-oni/docker-open-oni.git
+git clone https://github.com/open-oni/docker-open-oni.git
 
 # Wait until the clone is finished, then:
 cd docker-open-oni
-git clone git@github.com:open-oni/open-oni.git
+git clone https://github.com/open-oni/open-oni.git
 ```
 
 ### Quick setup


### PR DESCRIPTION
This is a very small PR to fix the documentation so that people are not required to belong to the open-oni organization in order to follow the instructions. I only noticed this because I was installing on a new machine where I hadn't set up my github identity yet...
