### PR TITLE
Rais iiif fixes

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -30,6 +30,7 @@ WORKDIR /opt/openoni
 
 ADD pip-install.sh /
 ADD load_batch.sh /
+ADD collect_static.sh /
 ADD startup.sh /
 ADD test.sh /
 ADD openoni.ini /etc/openoni.ini.orig

--- a/README.md
+++ b/README.md
@@ -25,19 +25,21 @@ git clone https://github.com/open-oni/open-oni.git
 
 ### Quick setup
 
-For a quick setup, just run [`./dev.sh`](dev.sh)  - it sets up all the
-containers in order, and makes sure the app is ready to run.  For Linux users
-who can't (or don't want to) expose port 80, the environment variable
-`DOCKERPORT` will override the default of using port 80.
+First, please set `APP_URL` to the public URL for your open-oni instance, for
+example:
 
-If the image view isn't working, it is likely because you're running docker on
-a system other than localhost (e.g., users of docker-machine, users running a
-demo on a system exposed to the public).  In these cases, you may have to
-export the environment variable `APP_URL` to point to your VM.  e.g., `export
-APP_URL=http://192.168.99.105`.
+    export APP_URL=http://oregonnews.uoregon.edu
 
-(Users of `docker-machine` who run the system inside a machine called "default"
-should have things working out of the box)
+You may want to put that in your `~/.profile` or equivalent so you don't forget
+to set it. As a convenience if you are using `docker-machine` on Windows or 
+OS X and have named your virtual machine `default` then `dev.sh` will attempt 
+to set APP_URL using using the virtual machine's IP address
+
+Now run [`./dev.sh`](dev.sh) which will set up all the containers in order, 
+and makes sure the app is ready to run.
+
+For Linux users who can't (or don't want to) expose port 80, the environment 
+variable `DOCKERPORT` will override the default of using port 80.
 
 ### Manual setup
 

--- a/apache/openoni.conf
+++ b/apache/openoni.conf
@@ -57,8 +57,8 @@ AliasMatch ^/(sitemap-\d+.xml)$ /opt/openoni/static/$1
 #CacheDirLevels 2
 
 # Change !RAIS_HOST! below to serve tiles and thumbnails from RAIS
-ProxyPass /images/tiles http://!RAIS_HOST!:12415/images/tiles
-ProxyPass /images/resize http://!RAIS_HOST!:12415/images/resize
+AllowEncodedSlashes NoDecode
+ProxyPass /images/iiif http://!RAIS_HOST!:12415/images/iiif nocanon
 
 #
 # Each directory to which Apache has access can be configured with respect

--- a/collect_static.sh
+++ b/collect_static.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source /opt/openoni/ENV/bin/activate
+
+cd /opt/openoni
+django-admin.py collectstatic --noinput

--- a/dev.sh
+++ b/dev.sh
@@ -14,7 +14,8 @@ if [ -z "$APP_URL" ]; then
     ip=$(docker-machine ip default)
     APP_URL="http://$ip"
   else
-    APP_URL="http://localhost"
+    echo "Please set the APP_URL environment variable"
+    exit -1
   fi
 
   if [ $PORT != 80 ]; then

--- a/dev.sh
+++ b/dev.sh
@@ -123,6 +123,8 @@ if [ -z "$RAIS_STATUS" ]; then
   docker run -d \
     -p 12415:12415 \
     --name openoni-dev-rais \
+    -e TILESIZES=512,1024 \
+    -e IIIFURL="$APP_URL/images/iiif" \
     -e PORT=12415 \
     -v $(pwd)/data/batches:/var/local/images:z \
     uolibraries/rais

--- a/openoni.ini
+++ b/openoni.ini
@@ -12,8 +12,7 @@ PASSWORD=openoni
 URL=http://!SOLR_HOST!:8983/solr
 
 [images]
-RESIZE_SERVER=!APP_URL!/images/resize
-TILE_SERVER=!APP_URL!/images/tiles
+IIIF_SERVER=!APP_URL!/images/iiif
 
 ; Secrets go here.  SHHH!
 [secrets]


### PR DESCRIPTION
These are changes to activate the IIIF Image API support in rais-image-server. The only significant change here is that setting `APP_URL` is required before running `dev.sh` unless you are using docker-machine. `dev.sh` will exit immediately if it isn't able to determine the URL for the application. 

This should be merged in at the same time as https://github.com/open-oni/open-oni/pull/127
